### PR TITLE
Role fails on RHEL/CentOS without SCSI

### DIFF
--- a/roles/ansible-manage-lvm/tasks/centos.yml
+++ b/roles/ansible-manage-lvm/tasks/centos.yml
@@ -21,3 +21,4 @@
   command: "/usr/bin/rescan-scsi-bus.sh"
   become: true
   changed_when: False
+  ignore_errors: true


### PR DESCRIPTION
## Description
On a NVMe only system role fails when doing rescanning for new disks

Making this task non mandatory to complete solves the problem.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
